### PR TITLE
system_info: adjust RAM quota for 4k

### DIFF
--- a/lvgl/system_info/pkg/system_info/runtime
+++ b/lvgl/system_info/pkg/system_info/runtime
@@ -1,4 +1,4 @@
-<runtime ram="25M" caps="2000" binary="system_info">
+<runtime ram="50M" caps="2000" binary="system_info">
 
 	<requires>
 		<gui/>


### PR DESCRIPTION
Adjust the default RAM quota to work on 4k screens.